### PR TITLE
Add layout submenu per node instead of per canvas

### DIFF
--- a/src/Hierarchical-Roassal-Menu/HRelayoutCanvasMenuItem.class.st
+++ b/src/Hierarchical-Roassal-Menu/HRelayoutCanvasMenuItem.class.st
@@ -7,40 +7,10 @@ Class {
 	#category : #'Hierarchical-Roassal-Menu'
 }
 
-{ #category : #public }
-HRelayoutCanvasMenuItem class >> definedLayouts [
-	 ^ { RSGridLayout . RSFlowLayout . RSCircleLayout }.
-]
-
-{ #category : #'building - menus' }
-HRelayoutCanvasMenuItem >> buildOn: aMenuMorph [
-	| submenu |
-	submenu := MenuMorph new.
-	self class definedLayouts do: [ :layoutClass |  
-		submenu
-		add: layoutClass name
-		target: self 
-		selector: #execute:  
-		argument: layoutClass.
-	].
-   aMenuMorph add: self label subMenu: submenu. 
-	
-]
-
 { #category : #execution }
 HRelayoutCanvasMenuItem >> execute [
 	| rootNode |
 	rootNode := visualization rootNode.
-	rootNode children do: [ :child | child position: nil ].
-	visualization layoutOn: visualization container nodes parent: rootNode.
-	visualization container signalUpdate.
-]
-
-{ #category : #execution }
-HRelayoutCanvasMenuItem >> execute: layoutClass [
-	| rootNode |
-	rootNode := visualization rootNode.
-	rootNode layout: layoutClass new.
 	rootNode children do: [ :child | child position: nil ].
 	visualization layoutOn: visualization container nodes parent: rootNode.
 	visualization container signalUpdate.

--- a/src/Hierarchical-Roassal-Menu/HRelayoutMenuItem.class.st
+++ b/src/Hierarchical-Roassal-Menu/HRelayoutMenuItem.class.st
@@ -8,11 +8,37 @@ Class {
 }
 
 { #category : #execution }
-HRelayoutMenuItem >> execute [
-	| node |
-	node := shape model.
+HRelayoutMenuItem >> applyLayout: node [
 	node children do: [ :child | child position: nil ].
 	visualization rebuildShape: shape.
+]
+
+{ #category : #'building - menus' }
+HRelayoutMenuItem >> buildOn: aMenuMorph [ 
+	| submenu |
+	submenu := MenuMorph new.
+	self class definedLayouts do: [ :layoutClass |  
+		submenu
+		add: layoutClass name
+		target: self 
+		selector: #execute:  
+		argument: layoutClass.
+	].
+   aMenuMorph add: self label subMenu: submenu. 
+]
+
+{ #category : #execution }
+HRelayoutMenuItem >> execute [
+	self applyLayout: shape model.
+]
+
+{ #category : #execution }
+HRelayoutMenuItem >> execute: layoutClass [ 
+   |node|
+   node := shape model.
+   node layout: layoutClass new.
+	self applyLayout: node.
+
 ]
 
 { #category : #accessing }

--- a/src/Hierarchical-Roassal-Menu/HRelayoutMenuItem.class.st
+++ b/src/Hierarchical-Roassal-Menu/HRelayoutMenuItem.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Hierarchical-Roassal-Menu'
 }
 
+{ #category : #accessing }
+HRelayoutMenuItem class >> definedLayouts [ 
+	 ^ { RSGridLayout . RSFlowLayout . RSCircleLayout }.
+
+]
+
 { #category : #execution }
 HRelayoutMenuItem >> applyLayout: node [
 	node children do: [ :child | child position: nil ].

--- a/src/Hierarchical-Roassal-Tests/HMenuBuilderTest.class.st
+++ b/src/Hierarchical-Roassal-Tests/HMenuBuilderTest.class.st
@@ -80,7 +80,7 @@ HMenuBuilderTest >> testMenuForNode [
 { #category : #tests }
 HMenuBuilderTest >> testSubmenuLayouts [
    |menuItem menuMorph|
- 	menuItem := HRelayoutCanvasMenuItem new.
+ 	menuItem := HRelayoutMenuItem new.
 	menuMorph := MenuMorph new.
 	menuItem buildOn: menuMorph.
 	self assert: menuMorph items size equals: 1.


### PR DESCRIPTION
- We removed the "relayout" submenu from the canvas because the layout selection already exists in settings and we want to avoid duplication. 
- We added "relayout" submenu to the nodes so now users can define the layout for each node individually, not only for the canvas.