### PR TITLE
Recursive expand

### DIFF
--- a/src/Hierarchical-Model/HNode.class.st
+++ b/src/Hierarchical-Model/HNode.class.st
@@ -267,8 +267,13 @@ HNode >> doesParentDisplayLinks [
 
 { #category : #public }
 HNode >> expand [
+
 	isExpanded := true.
-	self announce: (HExpandEvent new node: self)
+	self announce: (HExpandEvent new node: self).
+
+	"In case I have only 1 child of the same type as my model, I'll expand recusively because this is probably what the user will do in most cases.
+	This is a behavior equivalent to other IDE such as VSCode when a folder contains only one folder or as Intellij when a java package contains only one java package."
+	(self children size = 1 and: [ self rawModel class = self children anyOne rawModel class ]) ifTrue: [ self children anyOne expand ]
 ]
 
 { #category : #public }


### PR DESCRIPTION
Expand recursively the children of the hierarchical when there is only one child of the same type of its parent.

Fixes https://github.com/moosetechnology/MooseIDE/issues/1013